### PR TITLE
Ajout de l'entité Checkpoint et du repository JPA

### DIFF
--- a/src/main/java/com/example/SecurityCheckpointService/model/Checkpoint.java
+++ b/src/main/java/com/example/SecurityCheckpointService/model/Checkpoint.java
@@ -1,0 +1,19 @@
+package com.example.SecurityCheckpointService.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+public class Checkpoint {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String packageId;
+    private Long locationId;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/example/SecurityCheckpointService/repository/CheckpointRepository.java
+++ b/src/main/java/com/example/SecurityCheckpointService/repository/CheckpointRepository.java
@@ -1,0 +1,7 @@
+package com.example.SecurityCheckpointService.repository;
+
+import com.example.SecurityCheckpointService.model.Checkpoint;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CheckpointRepository extends JpaRepository<Checkpoint, Long> {
+}


### PR DESCRIPTION
Ajoute l’entité Checkpoint pour stocker les données des points de contrôle et le repository JPA pour les opérations CRUD